### PR TITLE
Allow to specify a sub menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ---
 currentMenu: home
+currentSubMenu: configuration
 ---
 
 # Read The Docs template for Couscous

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ menu:
             text: Another link
             # Or absolute urls
             absoluteUrl: https://example.com
+        group:
+            text: Link with a sub menu
+            relativeUrl: group.html
+            items:
+                anchor:
+                    text: Some anchor
+                    relativeUrl: group.html#some-anchor
+                link:
+                    text: Some link
+                    absoluteUrl: https://example.com
 ```
 
 Note that the menu items can also contain HTML:
@@ -69,6 +79,8 @@ currentMenu: home
 
 # Welcome
 ```
+
+When using sub menus you can also specify the `currentSubMenu` key.
 
 ## TODO
 

--- a/couscous.yml
+++ b/couscous.yml
@@ -15,6 +15,13 @@ menu:
             text: Home page
             # You can use relative urls
             relativeUrl:
+            items:
+                usage:
+                    text: Usage
+                    relativeUrl: '#'
+                configuration:
+                    text: Configuration
+                    relativeUrl: '#'
         getting-started:
             text: Getting Started
             relativeUrl:

--- a/css/theme-fixes.css
+++ b/css/theme-fixes.css
@@ -2,7 +2,63 @@
     margin-bottom: 0;
 }
 
-.wy-nav-side { overflow: inherit; } 
+.wy-nav-side { overflow: inherit; }
+
+/* Sub menu elements */
+.wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand {
+    display: block;
+    font-size: .8em;
+    line-height: 1.6em;
+    color:#333
+}
+
+a .wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li a span.toctree-expand, .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand {
+    display: inline-block;
+    text-decoration:inherit
+}
+
+.wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand {
+    font-family:inherit
+}
+
+.wy-menu-vertical li span.toctree-expand, .wy-menu-vertical li.on a span.toctree-expand, .wy-menu-vertical li.current > a span.toctree-expand {
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: inherit;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing:grayscale
+}
+
+.wy-menu-vertical li span.toctree-expand {
+    display: block;
+    float: left;
+    margin-left: -1.2em;
+    font-size: .8em;
+    line-height: 1.6em;
+    color:#4d4d4d
+}
+
+.wy-menu-vertical li.on a span.toctree-expand:before, .wy-menu-vertical li.current > a span.toctree-expand:before {
+    content: ""
+}
+
+.wy-menu-vertical li span.toctree-expand:before, .wy-menu-vertical li.on a span.toctree-expand:before, .wy-menu-vertical li.current > a span.toctree-expand:before {
+    font-family: "FontAwesome";
+    display: inline-block;
+    font-style: normal;
+    font-weight: normal;
+    line-height: 1;
+    text-decoration:inherit
+}
+
+.wy-menu-vertical li span.toctree-expand:before, .wy-menu-vertical li.on a span.toctree-expand:before, .wy-menu-vertical li.current > a span.toctree-expand:before {
+    -webkit-font-smoothing:antialiased
+}
+
+.wy-menu-vertical li span.toctree-expand:before {
+    content: ""
+}
 
 /* Code blocks */
 pre > code {

--- a/default.twig
+++ b/default.twig
@@ -28,6 +28,9 @@
                         <li class="toctree-l1 {{ activeMenu ? 'current' }}">
                             <a class="reference internal {{ activeMenu ? 'current' }}"
                                href="{{ item.absoluteUrl|default(baseUrl ~ '/' ~ item.relativeUrl) }}">
+                                {% if not activeMenu and item.items is defined %}
+                                    <span class="toctree-expand"></span>
+                                {% endif %}
                                 {{ item.text|raw }}
                             </a>
 

--- a/default.twig
+++ b/default.twig
@@ -24,11 +24,24 @@
             <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
                 <ul>
                     {% for itemId, item in menu.items %}
-                        <li class="toctree-l1 {{ itemId == currentMenu ? 'current' }}">
-                            <a class="reference internal {{ itemId == currentMenu ? 'current' }}"
+                        {% set activeMenu = (itemId == currentMenu) %}
+                        <li class="toctree-l1 {{ activeMenu ? 'current' }}">
+                            <a class="reference internal {{ activeMenu ? 'current' }}"
                                href="{{ item.absoluteUrl|default(baseUrl ~ '/' ~ item.relativeUrl) }}">
                                 {{ item.text|raw }}
                             </a>
+
+                            {% if activeMenu and item.items is defined %}
+                                <ul>
+                                    {% for subItem in item.items %}
+                                        <li class="toctree-l2">
+                                            <a class="reference internal" href="{{ subItem.absoluteUrl|default(baseUrl ~ '/' ~ subItem.relativeUrl) }}">
+                                                {{ subItem.text|raw }}
+                                            </a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% endif %}
                         </li>
                     {% endfor %}
                 </ul>

--- a/default.twig
+++ b/default.twig
@@ -33,9 +33,10 @@
 
                             {% if activeMenu and item.items is defined %}
                                 <ul>
-                                    {% for subItem in item.items %}
-                                        <li class="toctree-l2">
-                                            <a class="reference internal" href="{{ subItem.absoluteUrl|default(baseUrl ~ '/' ~ subItem.relativeUrl) }}">
+                                    {% for subItemId,subItem in item.items %}
+                                        {% set activeSubMenu = (subItemId == currentSubMenu) %}
+                                        <li class="toctree-l2 {{ activeSubMenu ? 'current' }}">
+                                            <a class="reference internal {{ activeSubMenu ? 'current' }}" href="{{ subItem.absoluteUrl|default(baseUrl ~ '/' ~ subItem.relativeUrl) }}">
                                                 {{ subItem.text|raw }}
                                             </a>
                                         </li>


### PR DESCRIPTION
# Need

The original ReadTheDocs template supports sub menus in the sidebar. This template should also support this feature.

# Implementation

- Allow to specify `items` in a top level item, with sub items having the same structure as the top level ones (keys: `text`, `relativeUrl` and `absoluteUrl`
- Sub menus are only displayed for the currently opened top level menu
- When a top (non active) level item has a sub menu a little `+` symbol is displayed on the left (to invite people to go discover the sub menu)

<img width="300" alt="Screenshot 2021-02-20 at 18 00 50" src="https://user-images.githubusercontent.com/851425/108603214-f9582180-73a6-11eb-881b-67b4c341831e.png">
<img width="296" alt="Screenshot 2021-02-20 at 18 01 09" src="https://user-images.githubusercontent.com/851425/108603216-f9f0b800-73a6-11eb-928c-275dd73aff99.png">

# Notes

- The css comes from the original RTD template (though a copy/paste via the web inspector)
  - the css is in `theme-fixes.css` as this file doesn't seem to be generated and I don't know to generate the `theme.css` from the sass files
- The `+` symbol is originally always present with the capability to open/close on click. I didn't implement this feature to keep things (and js file) simple
- The current implementation should not break existing projects